### PR TITLE
Fix typo

### DIFF
--- a/src/common/stream.rs
+++ b/src/common/stream.rs
@@ -227,7 +227,7 @@ impl<T : Types> HttpStreamCommon<T> {
             };
 
         // Max of connection and stream window size
-        let max_window = cmp::min(self.out_window_size.size(), conn_out_window_size.size());
+        let max_window = cmp::max(self.out_window_size.size(), conn_out_window_size.size());
 
         if data.len() as usize > max_window as usize {
             trace!("truncating data of len {} to {}", data.len(), max_window);
@@ -289,5 +289,3 @@ pub trait HttpStreamDataSpecific {
 pub trait HttpStream {
     type Types : Types;
 }
-
-


### PR DESCRIPTION
change cmp::min to cmp::max as the comment above states
This fixes an endless loop if the size of an message is bigger then the
window size