### PR TITLE
Unix socket tests should use tempdir crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ bytes = "0.*"
 [target.'cfg(unix)'.dependencies]
 tokio-uds       = "0.*"
 unix_socket     = "0.*"
-tempdir         = "0.*"
 
 [dev-dependencies]
 
@@ -37,6 +36,10 @@ regex              = "0.2"
 tls-api-native-tls = "0.*"
 tls-api-openssl    = "0.*"
 url                = "1"
+
+[target.'cfg(unix)'.dev-dependencies]
+
+tempdir         = "0.*"
 
 [workspace]
 members = ["interop/with-rust"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ bytes = "0.*"
 [target.'cfg(unix)'.dependencies]
 tokio-uds       = "0.*"
 unix_socket     = "0.*"
+tempdir         = "0.*"
 
 [dev-dependencies]
 

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -44,6 +44,8 @@ use std::sync::mpsc;
 #[cfg(unix)]
 extern crate unix_socket;
 #[cfg(unix)]
+extern crate tempdir;
+#[cfg(unix)]
 use unix_socket::UnixStream;
 
 use test_misc::*;
@@ -401,9 +403,11 @@ pub fn http_1_1() {
 pub fn http_1_1_unix() {
     env_logger::init().ok();
 
-    let _server = ServerTest::new_unix("/tmp/rust_http2_test".to_owned());
+    let tempdir = tempdir::TempDir::new("rust_http2_test").unwrap();
+    let socket_path = tempdir.path().join("test_socket");
+    let _server = ServerTest::new_unix(socket_path.to_str().unwrap().to_owned());
 
-    let mut unix_stream = UnixStream::connect("/tmp/rust_http2_test").expect("connect");
+    let mut unix_stream = UnixStream::connect(socket_path).expect("connect");
 
     unix_stream.write_all(b"GET / HTTP/1.1\n").expect("write");
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -6,6 +6,8 @@ extern crate tokio_core;
 #[macro_use]
 extern crate log;
 extern crate env_logger;
+#[cfg(unix)]
+extern crate tempdir;
 
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -51,7 +53,10 @@ fn smoke() {
 #[test]
 fn smoke_unix_domain_sockets() {
     env_logger::init().ok();
-    let test_addr = "/tmp/rust_http2_smoke_test";
+
+    let tempdir = tempdir::TempDir::new("rust_http2_test").unwrap();
+    let socket_path = tempdir.path().join("test_socket");
+    let test_addr = socket_path.to_str().unwrap();
 
     let _server = ServerTest::new_unix(test_addr.to_owned());
 

--- a/tests/test_misc/server_test.rs
+++ b/tests/test_misc/server_test.rs
@@ -22,6 +22,7 @@ pub struct ServerTest {
     pub port: u16,
 }
 
+
 struct Blocks {}
 
 impl Service for Blocks {

--- a/tests/test_misc/server_test.rs
+++ b/tests/test_misc/server_test.rs
@@ -22,7 +22,6 @@ pub struct ServerTest {
     pub port: u16,
 }
 
-
 struct Blocks {}
 
 impl Service for Blocks {


### PR DESCRIPTION
Use tempdir crate to automatically create and delete temporary directory for unix domain socket tests.