### PR TITLE
Allow for `Headers` to be `.collect()` from an iterator of `Header`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ futures-cpupool = "0.*"
 tokio-core      = "0.*"
 tokio-io        = "0.*"
 tokio-timer     = "0.*"
-tokio-tls-api   = "0.*"
-tls-api         = "0.*"
-tls-api-stub    = "0.*"
+tokio-tls-api   = { git = "https://github.com/valarauca/rust-tls-api" }
+tls-api         = { git = "https://github.com/valarauca/rust-tls-api" }
+tls-api-stub    = { git = "https://github.com/valarauca/rust-tls-api" }
 void            = "1"
 net2 = "0.2"
 bytes = "0.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ futures-cpupool = "0.*"
 tokio-core      = "0.*"
 tokio-io        = "0.*"
 tokio-timer     = "0.*"
-tokio-tls-api   = { git = "https://github.com/valarauca/rust-tls-api" }
-tls-api         = { git = "https://github.com/valarauca/rust-tls-api" }
-tls-api-stub    = { git = "https://github.com/valarauca/rust-tls-api" }
+tokio-tls-api   = { version = "0.1.10" }
+tls-api         = { version = "0.1.10" }
+tls-api-stub    = { version = "0.1.10" }
 void            = "1"
 net2 = "0.2"
 bytes = "0.*"

--- a/src/client.rs
+++ b/src/client.rs
@@ -63,9 +63,6 @@ impl<C : TlsConnector> ClientBuilder<C> {
         let addrs: Vec<_> = addr.to_socket_addrs()?.collect();
         if addrs.is_empty() {
             return Err(Error::Other("addr is resolved to empty list"));
-        } else if addrs.len() > 1 {
-            // TODO: allow multiple addresses
-            return Err(Error::Other("addr is resolved to more than one addr"));
         }
         self.addr = Some(AnySocketAddr::Inet(addrs.into_iter().next().unwrap()));
         Ok(())

--- a/src/client_conn.rs
+++ b/src/client_conn.rs
@@ -387,7 +387,7 @@ impl Service for ClientConnection {
             return Response::err(error::Error::Other("client died"));
         }
 
-        let resp_rx = resp_rx.map_err(|oneshot::Canceled| error::Error::Other("client likely died"));
+        let resp_rx = resp_rx.map_err(|e| error::Error::InvalidFrame(format!("client likely died {:?}", e)));
 
         let resp_rx = resp_rx.map(|r| r.into_stream_flag());
 

--- a/src/client_conn.rs
+++ b/src/client_conn.rs
@@ -315,7 +315,7 @@ impl ClientConnection {
 
         let tls_conn = connect.and_then(move |conn| {
             tokio_tls_api::connect_async(&*connector, &domain, conn).map_err(|e| {
-                Error::IoError(io::Error::new(io::ErrorKind::Other, e))
+                Error::IoError(io::Error::new(io::ErrorKind::Other, format!("TLS connection failed {:?}", e)))
             })
         });
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -327,6 +327,11 @@ fn spawn_server_event_loop<S, A>(
 }
 
 impl Server {
+
+    pub fn socket_addr(&self) -> &::std::net::SocketAddr {
+        &self.local_addr.get_addr()
+    }
+
     pub fn local_addr(&self) -> &AnySocketAddr {
         &self.local_addr
     }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -27,6 +27,15 @@ pub enum AnySocketAddr {
     #[cfg(unix)]
     Unix(String)
 }
+impl AnySocketAddr {
+    pub fn get_addr(&self) -> &::std::net::SocketAddr {
+        match self {
+            &AnySocketAddr::Inet(ref socket) => socket,
+            #[cfg(unix)]
+            &AnySocketAddr::Unix(_) => panic!("Unix not supported")
+        }
+    }
+}
 
 impl Display for AnySocketAddr {
     fn fmt(&self, f: &mut Formatter) -> ::std::fmt::Result {

--- a/src/solicit/header.rs
+++ b/src/solicit/header.rs
@@ -1,6 +1,7 @@
 use std::str;
 use std::str::FromStr;
 use std::fmt;
+use std::iter::FromIterator;
 
 use req_resp::RequestOrResponse;
 
@@ -204,6 +205,12 @@ impl<N: Into<HeaderPart>, V: Into<HeaderPart>> From<(N, V)> for Header {
 
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
 pub struct Headers(pub Vec<Header>);
+
+impl FromIterator<Header> for Headers {
+    fn from_iter<T: IntoIterator<Item=Header>>(iter: T) -> Headers {
+        Headers( iter.into_iter().collect())
+    }
+}
 
 impl Headers {
     pub fn new() -> Headers {


### PR DESCRIPTION
Very minor change just to make the api a bit nicer to work with when converting an existing `curl`/`hyper` library to use this library.