### PR TITLE
Fix for connecting to hosts with multiple IP/DNS Records

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tls-api-stub    = "0.*"
 void            = "1"
 net2 = "0.2"
 bytes = "0.*"
+rand = "0.3.16"
 
 [target.'cfg(unix)'.dependencies]
 tokio-uds       = "0.*"

--- a/src/client.rs
+++ b/src/client.rs
@@ -75,7 +75,7 @@ impl<C : TlsConnector> ClientBuilder<C> {
                     Ok(x) => x,
                     Err(e) => return Err(error::Error::IoError(e))
                 };
-                let range = rng.gen_range(0,x);
+                let range = rng.gen_range(0,x-1);
                 self.addr = Some(AnySocketAddr::Inet(addrs[x].clone()));
                 Ok(())
             }

--- a/src/client.rs
+++ b/src/client.rs
@@ -13,6 +13,9 @@ use futures::sync::mpsc::UnboundedSender;
 use futures::sync::mpsc::UnboundedReceiver;
 use futures::sync::oneshot;
 
+use rand::os::OsRng;
+use rand::Rng;
+
 use tokio_core::reactor;
 
 use tls_api::TlsConnector;
@@ -60,15 +63,23 @@ impl<C : TlsConnector> ClientBuilder<C> {
     /// Set the addr client connects to.
     pub fn set_addr<S : ToSocketAddrs>(&mut self, addr: S) -> Result<()> {
         // TODO: sync
-        let addrs: Vec<_> = addr.to_socket_addrs()?.collect();
-        if addrs.is_empty() {
-            return Err(Error::Other("addr is resolved to empty list"));
-        } else if addrs.len() > 1 {
-            // TODO: allow multiple addresses
-            return Err(Error::Other("addr is resolved to more than one addr"));
+        let mut addrs: Vec<_> = addr.to_socket_addrs()?.collect();
+        match addrs.len() {
+            0 => Err(Error::Other("addr is resolved to empty list")),
+            1 => {
+                self.addr = Some(AnySocketAddr::Inet(addrs[0].clone()));
+                Ok(())
+            }
+            x => {
+                let mut rng = match OsRng::new() {
+                    Ok(x) => x,
+                    Err(e) => return Err(error::Error::IoError(e))
+                };
+                let range = rng.gen_range(0,x);
+                self.addr = Some(AnySocketAddr::Inet(addrs[x].clone()));
+                Ok(())
+            }
         }
-        self.addr = Some(AnySocketAddr::Inet(addrs.into_iter().next().unwrap()));
-        Ok(())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ extern crate log;
 extern crate futures;
 extern crate futures_cpupool;
 
+extern crate rand;
 extern crate tokio_core;
 extern crate tokio_io;
 extern crate tokio_timer;


### PR DESCRIPTION
Pulls in `rand` to use `OsRng` to select which host to connect too. 

_slight_ over kill, but it seems to work for a quick fix.