### PR TITLE
Pin futures related deps to `0.1.*`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ doctest = false
 [dependencies]
 
 log             = "0.4"
-futures         = "0.1"
-futures-cpupool = "0.1"
-tokio-core      = "0.1"
-tokio-io        = "0.1"
-tokio-timer     = "0.1"
+futures         = "0.1.*"
+futures-cpupool = "0.1.*"
+tokio-core      = "0.1.*"
+tokio-io        = "0.1.*"
+tokio-timer     = "0.1.*"
 tokio-tls-api   = "0.1"
 tls-api         = "0.1"
 tls-api-stub    = "0.1"


### PR DESCRIPTION
I've used this update, along with my updates in [rust-tls-api](https://github.com/stepancheg/rust-tls-api/pull/19) & [grpc-rust](https://github.com/stepancheg/grpc-rust/pull/113), integrated them into my create, and things appear to be back in order.